### PR TITLE
Revamp editor layout

### DIFF
--- a/src/components/TreeControls.jsx
+++ b/src/components/TreeControls.jsx
@@ -18,26 +18,58 @@ const TreeControls = ({ tree, selectedPersonId, onSelectPerson, onAddPerson, onA
 
   return (
     <div className="controls">
-      <button onClick={onResetTree}>Start fresh</button>
-      <select value={selectedPersonId || ''} onChange={e => onSelectPerson(e.target.value || null)}>
-        <option value="">-- select person --</option>
-        {tree && Object.values(tree.nodes).map(p => <option key={p.id} value={p.id}>{p.name}</option>)
-        }
-      </select>
-
-      <input value={newName} onChange={e => setNewName(e.target.value)} placeholder="New person's name" />
-
-      {selectedPersonId && (
-        <div className="add-buttons">
-          <button disabled={!newName} onClick={() => handleAdd('child')}>Add Child</button>
-          <button disabled={!newName} onClick={() => handleAdd('parent')}>Add Parent</button>
-          <button disabled={!newName} onClick={() => handleAdd('spouse')}>Add Spouse</button>
-          <button disabled={!newName} onClick={() => handleAdd('sibling')}>Add Sibling</button>
-          <button onClick={onDeletePerson} style={{ marginLeft: '10px', backgroundColor: '#ef4444', color: 'white' }}>Delete Person</button>
+      <div className="controls__section">
+        <div className="controls__header">
+          <h2>Build your tree</h2>
+          <button type="button" className="button button--ghost" onClick={onResetTree}>Start fresh</button>
         </div>
-      )}
+        <p className="controls__hint">Changes are saved automatically in this browser.</p>
+      </div>
 
-      <button disabled={!newName} onClick={handleAddTopLevel}>Add at top-level</button>
+      <div className="controls__section">
+        <label className="field">
+          <span className="field__label">Focus on a person</span>
+          <select className="field__input" value={selectedPersonId || ''} onChange={e => onSelectPerson(e.target.value || null)}>
+            <option value="">-- select person --</option>
+            {tree && Object.values(tree.nodes).map(p => (
+              <option key={p.id} value={p.id}>{p.name}</option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      <div className="controls__section">
+        <label className="field">
+          <span className="field__label">New person's name</span>
+          <input
+            className="field__input"
+            value={newName}
+            onChange={e => setNewName(e.target.value)}
+            placeholder="e.g. Alex Garcia"
+          />
+        </label>
+
+        {selectedPersonId ? (
+          <div className="controls__actions">
+            <div className="controls__actions-title">Add relative</div>
+            <div className="controls__button-grid">
+              <button type="button" disabled={!newName} onClick={() => handleAdd('child')} className="button">Child</button>
+              <button type="button" disabled={!newName} onClick={() => handleAdd('parent')} className="button">Parent</button>
+              <button type="button" disabled={!newName} onClick={() => handleAdd('spouse')} className="button">Spouse</button>
+              <button type="button" disabled={!newName} onClick={() => handleAdd('sibling')} className="button">Sibling</button>
+            </div>
+            <button type="button" className="button button--danger" onClick={onDeletePerson}>Delete selected person</button>
+          </div>
+        ) : (
+          <p className="controls__hint">Select someone above to add relatives around them.</p>
+        )}
+      </div>
+
+      <div className="controls__section">
+        <button type="button" disabled={!newName} onClick={handleAddTopLevel} className="button button--primary">
+          Add as new root person
+        </button>
+      </div>
     </div>
   );
 };

--- a/src/components/TreeEditor.jsx
+++ b/src/components/TreeEditor.jsx
@@ -116,18 +116,20 @@ const TreeEditor = () => {
 
   return (
     <div className="tree-editor">
-      <TreeControls
-        tree={tree}
-        selectedPersonId={selectedPersonId}
-        onSelectPerson={setSelectedPersonId}
-        onAddPerson={handleAddPerson}
-        onAddTopLevel={handleAddTopLevel}
-        onResetTree={handleResetTree}
-        onDeletePerson={handleDeletePerson}
-      />
-      <div className="trees">
+      <aside className="controls-panel">
+        <TreeControls
+          tree={tree}
+          selectedPersonId={selectedPersonId}
+          onSelectPerson={setSelectedPersonId}
+          onAddPerson={handleAddPerson}
+          onAddTopLevel={handleAddTopLevel}
+          onResetTree={handleResetTree}
+          onDeletePerson={handleDeletePerson}
+        />
+      </aside>
+      <section className="tree-viewport">
         {renderTree()}
-      </div>
+      </section>
     </div>
   );
 };

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,21 +1,43 @@
-:root{font-family: system-ui,Segoe UI,Roboto,Helvetica,Arial}
-body{margin:0;padding:20px;background:#f7fafc;color:#0f172a}
-.app{max-width:900px;margin:0 auto}
-header{display:flex;align-items:baseline;gap:12px}
+:root{font-family:system-ui,Segoe UI,Roboto,Helvetica,Arial;background:#f3f4f6;color-scheme:light dark}
+body{margin:0;padding:32px;background:linear-gradient(135deg,#f8fafc 0%,#eef2ff 100%);color:#0f172a}
+.app{max-width:1100px;margin:0 auto;display:flex;flex-direction:column;gap:24px}
+header{display:flex;align-items:flex-start;justify-content:space-between;flex-wrap:wrap;gap:12px;background:#ffffffdd;padding:16px 20px;border-radius:16px;box-shadow:0 12px 30px -24px rgba(15,23,42,.8)}
+header h1{margin:0;font-size:32px;font-weight:700;color:#0f172a}
+header p{margin:0;color:#475569}
 .person-node{margin-left:12px;padding:6px;border-left:1px dotted #cbd5e1}
 .person-row{display:flex;gap:8px;align-items:center}
 .person-name{font-weight:600}
 .children{margin-left:12px}
 .person-node.selected{background:#e0f2fe;border-radius:6px;padding-left:10px}
-.spouse{font-size:0.9em;color:#334155;margin-left:28px}
-.controls{display:flex;gap:8px;margin:12px 0}
-input{padding:6px;border-radius:4px;border:1px solid #cbd5e1}
-button{padding:6px 8px;border-radius:6px;border:1px solid #94a3b8;background:white;cursor:pointer}
-/* Graph styles */
-.graph-container{overflow:auto;border:1px solid #e2e8f0;border-radius:8px;background:white}
+.spouse{font-size:.9em;color:#334155;margin-left:28px}
+.tree-editor{display:grid;grid-template-columns:minmax(280px,340px) 1fr;gap:24px;align-items:flex-start}
+.tree-viewport{background:#fff;border-radius:20px;padding:20px;box-shadow:0 24px 50px -40px rgba(15,23,42,.6);min-height:360px;display:flex;align-items:center;justify-content:center}
+.controls-panel{position:sticky;top:24px}
+.controls{display:flex;flex-direction:column;gap:20px;background:#ffffff;border-radius:20px;padding:20px;box-shadow:0 18px 40px -32px rgba(30,41,59,.6)}
+.controls__section{display:flex;flex-direction:column;gap:12px}
+.controls__header{display:flex;align-items:center;justify-content:space-between;gap:12px}
+.controls__header h2{margin:0;font-size:20px;font-weight:600;color:#0f172a}
+.controls__hint{margin:0;font-size:14px;color:#64748b}
+.controls__actions{display:flex;flex-direction:column;gap:12px;background:#f8fafc;border-radius:16px;padding:16px}
+.controls__actions-title{font-weight:600;color:#0f172a}
+.controls__button-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:8px}
+.field{display:flex;flex-direction:column;gap:6px}
+.field__label{font-size:13px;font-weight:600;color:#1e293b;text-transform:uppercase;letter-spacing:.08em}
+.field__input{padding:10px 12px;border-radius:10px;border:1px solid #cbd5e1;background:#f8fafc;color:#0f172a;font-size:15px}
+.field__input:focus{outline:2px solid #38bdf8;outline-offset:2px}
+.button{padding:10px 12px;border-radius:12px;border:1px solid #cbd5e1;background:#fff;color:#0f172a;font-weight:600;cursor:pointer;transition:transform .15s ease,box-shadow .15s ease,background .15s ease}
+.button:disabled{opacity:.5;cursor:not-allowed;transform:none;box-shadow:none}
+.button:not(:disabled):hover{transform:translateY(-1px);box-shadow:0 10px 20px -18px rgba(15,23,42,.8)}
+.button--primary{background:#0ea5e9;color:#f8fafc;border-color:#0ea5e9}
+.button--primary:not(:disabled):hover{background:#0284c7}
+.button--ghost{background:transparent;border-color:transparent;color:#0f172a;padding:8px 10px}
+.button--ghost:not(:disabled):hover{background:#f1f5f9}
+.button--danger{background:#ef4444;color:#fff;border-color:#ef4444}
+.button--danger:not(:disabled):hover{background:#dc2626}
+.graph-container{overflow:auto;border:1px solid #e2e8f0;border-radius:16px;background:linear-gradient(145deg,#f8fafc,#e2e8f0)}
 .edge{stroke:#64748b;stroke-width:1.5;fill:none}
 .node-box{fill:#f8fafc;stroke:#94a3b8;stroke-width:1}
 .node.selected .node-box{stroke:#0ea5e9;stroke-width:2}
-.node-label{font-family: Segoe UI, system-ui, sans-serif;font-size:14px;fill:#0f172a}
-.marriage-node-box{fill:#334155;stroke:#334155;}
-.sibling-edge{stroke-dasharray: 2, 2;}
+.node-label{font-family:Segoe UI,system-ui,sans-serif;font-size:14px;fill:#0f172a}
+.marriage-node-box{fill:#334155;stroke:#334155}
+.sibling-edge{stroke-dasharray:2,2}


### PR DESCRIPTION
## Summary
- rearrange the tree editor into a two-column layout with a dedicated control panel
- redesign the controls with grouped sections, improved labels, and clearer button hierarchy
- refresh the global styling to provide a clean, card-based interface while keeping existing behavior

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5ac2680a083238f81824ea4f9d7ac