### PR TITLE
Adjust TreeControls layout spacing

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -121,13 +121,19 @@ body {
   gap: 6px;
 }
 
+.controls__grid {
+  display: grid;
+  grid-template-columns: minmax(220px, 320px) minmax(260px, 1fr);
+  gap: 20px;
+  align-items: start;
+}
+
 .controls__field {
-  flex: 1 1 200px;
-  min-width: 200px;
+  width: 100%;
 }
 
 .controls__field--name {
-  min-width: 240px;
+  max-width: 320px;
 }
 
 .controls__name-row {
@@ -160,19 +166,38 @@ body {
   flex-wrap: wrap;
 }
 
+.controls__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 16px;
+  background: #f8fafc;
+  border-radius: 16px;
+  box-shadow: inset 0 0 0 1px #e2e8f0;
+}
+
 .controls__actions-title {
   font-weight: 600;
   color: #0f172a;
 }
 
-.controls__delete-button {
-  flex-shrink: 0;
-}
-
 .controls__button-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-  gap: 8px;
+  grid-template-columns: repeat(2, minmax(120px, 1fr));
+  gap: 12px;
+}
+
+.controls__actions > .button {
+  align-self: flex-start;
+}
+
+.controls__root {
+  display: flex;
+  align-items: flex-start;
+}
+
+.controls__root .button {
+  width: 100%;
 }
 
 .field {
@@ -311,13 +336,20 @@ body {
     padding: 16px;
   }
 
-  .controls__name-row {
-    flex-direction: column;
-    align-items: stretch;
+  .controls__grid {
+    grid-template-columns: 1fr;
   }
 
-  .controls__root-button {
-    width: 100%;
+  .controls__field--name {
+    max-width: none;
+  }
+
+  .controls__actions {
+    padding: 12px 14px;
+  }
+
+  .controls__button-grid {
+    grid-template-columns: 1fr;
   }
 }
 


### PR DESCRIPTION
## Summary
- limit the new person name input width and arrange the control panel with a two-column grid
- restyle the action and root sections so buttons have consistent spacing across viewports

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d659ab492883238dcd790286088d89